### PR TITLE
Build executable - new command line switch -o

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -23,8 +23,11 @@ var descTagsOption = "Filter scenarios by tags. Expression can be:\n" +
 	s(4) + "- " + cl(`"@wip && ~@new"`, yellow) + ": run wip scenarios, but exclude new\n" +
 	s(4) + "- " + cl(`"@wip,@undone"`, yellow) + ": run wip or undone scenarios"
 
+var descOutputOption = "Output the temporary test runner executable:\n" +
+	s(4) + "- supply the name to give the executable " + cl("test_features.exe", yellow) + "\n" 
+
 // FlagSet allows to manage flags by external suite runner
-func FlagSet(format, tags *string, defs, sof, noclr *bool, cr *int) *flag.FlagSet {
+func FlagSet(format, tags *string, defs, sof, noclr *bool, cr *int, output *string) *flag.FlagSet {
 	descFormatOption := "How to format tests output. Available formats:\n"
 	for _, f := range formatters {
 		descFormatOption += s(4) + "- " + cl(f.name, yellow) + ": " + f.description + "\n"
@@ -42,6 +45,8 @@ func FlagSet(format, tags *string, defs, sof, noclr *bool, cr *int) *flag.FlagSe
 	set.BoolVar(defs, "d", false, "Print all available step definitions.")
 	set.BoolVar(sof, "stop-on-failure", false, "Stop processing on first failed scenario.")
 	set.BoolVar(noclr, "no-colors", false, "Disable ansi colors.")
+    set.StringVar(output, "output", "", descOutputOption)
+    set.StringVar(output, "o", "", descOutputOption)
 	set.Usage = usage(set)
 	return set
 }

--- a/run.go
+++ b/run.go
@@ -74,9 +74,9 @@ func (r *runner) run() (failed bool) {
 // the step definitions and event handlers.
 func Run(contextInitializer func(suite *Suite)) int {
 	var defs, sof, noclr bool
-	var tags, format string
+	var tags, format, output string
 	var concurrency int
-	flagSet := FlagSet(&format, &tags, &defs, &sof, &noclr, &concurrency)
+	flagSet := FlagSet(&format, &tags, &defs, &sof, &noclr, &concurrency, &output)
 	err := flagSet.Parse(os.Args[1:])
 	fatal(err)
 


### PR DESCRIPTION
This change adds support for a new switch (-o) which is used to generate a copy of the test runner executable instead of running any tests.
This allows features to be run in environments where a full Go installation is not available.

Having struggled to find a suitable way to provide a unit test for this feature I'm raising the pull request in the hope that smarter minds than mine might have a suggestion.