### PR TITLE
New: possibility to print delayed messages in an external lib or in your tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,13 +246,19 @@ func minimaleFunc(suite string, out io.Writer) godog.Formatter {
 		out:     out,
 		indent:  2,
 		started: time.Now(),
+    delayedMessageWriter: godog.NewDelayedMessagesWriter(),
 	}
 }
 
 type minimale struct {
+  delayedMessageWriter *godog.DelayedMessagesWriter
 	out     io.Writer
 	indent  int
 	started time.Time
+}
+
+func (m *minimale)Output() io.writer {
+  return m.delayedMessageWriter
 }
 
 func (m *minimale) Feature(f *gherkin.Feature, s, string, b, []byte) {
@@ -295,10 +301,16 @@ func (m *minimale) Summary() {
 }
 ```
 
-Then make sure to import this package in your mail file :
+Then make sure to import this package in your main file:
 
 ```go
 import _ "path"
+```
+
+Now to print any messages in your tests or external library:
+
+```go
+fmt.Fprintln(c.suite.Output(), strings.Repeat(" ", 10)+colors.Cyan("my log"))
 ```
 
 ### References and Tutorials

--- a/README.md
+++ b/README.md
@@ -228,6 +228,79 @@ func TestMain(m *testing.M) {
 }
 ```
 
+### Usage of a custom formatter
+
+You can implement a custom format when running godog. To achieve that, you need to implement a struct which implement the interface Formatter.
+
+See the following example :
+
+```go
+package fmtminimale
+
+func init() {
+	godog.Format("minimale", "Prints minimal status", minimaleFunc)
+}
+
+func minimaleFunc(suite string, out io.Writer) godog.Formatter {
+	return &minimale{
+		out:     out,
+		indent:  2,
+		started: time.Now(),
+	}
+}
+
+type minimale struct {
+	out     io.Writer
+	indent  int
+	started time.Time
+}
+
+func (m *minimale) Feature(f *gherkin.Feature, s, string, b, []byte) {
+  fmt.Println("[FEATURE]" + f.Name)
+}
+
+func (m *minimale) Node(node interface{}) {
+  switch t := node.(type) {
+  case *gherkin.Scenario:
+    fmt.Println("[SCENARIO]" + t.Name)
+  }
+}
+
+func (m *minimale) Defined(s *gherkin.Step, sd *godog.StepDef) {
+  fmt.Println("[DEFINED]" + s.Name)
+}
+
+func (m *minimale) Failed(s *gherkin.Step, sd *godog.StepDef, e error) {
+  fmt.Println("[FAILED]" + s.Name)
+}
+
+func (m *minimale) Passed(s *gherkin.Step, sd *godog.StepDef) {
+  fmt.Println("[PASSED]" + s.Name)
+}
+
+func (m *minimale) Skipped(s *gherkin.Step) {
+  fmt.Println("[SKIPPED]" + s.Name)
+}
+
+func (m *minimale) Undefined(s *gherkin.Step) {
+  fmt.Println("[UNDEFINED]" + s.Name)
+}
+
+func (m *minimale) Pending(s *gherkin.Step, sd *godog.StepDef) {
+  fmt.Println("[PENDING]" + s.Name)
+}
+
+func (m *minimale) Summary() {
+  fmt.Println("[END]")
+}
+```
+
+Then make sure to import this package in your mail file :
+
+```go
+import _ "path"
+```
+
 ### References and Tutorials
 
 - [how to use godog by semaphoreci](https://semaphoreci.com/community/tutorials/how-to-use-godog-for-behavior-driven-development-in-go)

--- a/cmd/godog/main.go
+++ b/cmd/godog/main.go
@@ -36,6 +36,7 @@ func buildAndRun() (int, error) {
 	cmd := exec.Command(bin, os.Args[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 	cmd.Env = os.Environ()
 
 	if err = cmd.Start(); err != nil {

--- a/flags.go
+++ b/flags.go
@@ -33,6 +33,7 @@ func FlagSet(opt *Options) *flag.FlagSet {
 	for name, desc := range AvailableFormatters() {
 		descFormatOption += s(4) + "- " + colors.Yellow(name) + ": " + desc + "\n"
 	}
+	descFormatOption += s(4) + "- " + colors.Yellow("<format>") + ": name of your custom format" + "\n"
 	descFormatOption = strings.TrimSpace(descFormatOption)
 
 	set := flag.NewFlagSet("godog", flag.ExitOnError)

--- a/fmt.go
+++ b/fmt.go
@@ -37,6 +37,8 @@ var undefinedSnippetsTpl = template.Must(template.New("snippets").Funcs(snippetH
 }
 `))
 
+var godogFormats = []string{"events", "junit", "pretty", "progress"}
+
 type undefinedSnippet struct {
 	Method   string
 	Expr     string

--- a/fmt_events.go
+++ b/fmt_events.go
@@ -22,6 +22,7 @@ func eventsFunc(suite string, out io.Writer) Formatter {
 			started: time.Now(),
 			indent:  2,
 			out:     out,
+			delayedMessagesWriter: NewDelayedMessagesWriter(),
 		},
 	}
 

--- a/fmt_junit.go
+++ b/fmt_junit.go
@@ -38,6 +38,10 @@ type junitFormatter struct {
 	outlineExample int
 }
 
+func (j *junitFormatter) Output() io.Writer {
+	return j.out
+}
+
 func (j *junitFormatter) Feature(feature *gherkin.Feature, path string, c []byte) {
 	testSuite := &junitTestSuite{
 		TestCases: make([]*junitTestCase, 0),

--- a/fmt_progress.go
+++ b/fmt_progress.go
@@ -20,6 +20,7 @@ func progressFunc(suite string, out io.Writer) Formatter {
 			started: time.Now(),
 			indent:  2,
 			out:     out,
+			delayedMessagesWriter: NewDelayedMessagesWriter(),
 		},
 		stepsPerRow: 70,
 	}

--- a/run.go
+++ b/run.go
@@ -97,7 +97,16 @@ func RunWithOptions(suite string, contextInitializer func(suite *Suite), opt Opt
 		}
 	}
 
-	if opt.Concurrency > 1 && opt.Format != "progress" {
+	isGodogFormat := false
+
+	for _, godogFormat := range godogFormats {
+		if godogFormat == opt.Format {
+			isGodogFormat = true
+			break
+		}
+	}
+
+	if isGodogFormat && opt.Concurrency > 1 && opt.Format != "progress" {
 		fatal(fmt.Errorf("when concurrency level is higher than 1, only progress format is supported"))
 	}
 	formatter, err := findFmt(opt.Format)

--- a/run.go
+++ b/run.go
@@ -17,7 +17,8 @@ type runner struct {
 	initializer   initializer
 }
 
-func (r *runner) concurrent(rate int) (failed bool) {
+func (r *runner) concurrent(rate int, f FormatterFunc, s string, output io.Writer) (failed bool) {
+
 	queue := make(chan int, rate)
 	for i, ft := range r.features {
 		queue <- i // reserve space in queue
@@ -29,7 +30,7 @@ func (r *runner) concurrent(rate int) (failed bool) {
 				return
 			}
 			suite := &Suite{
-				fmt:           r.fmt,
+				fmt:           f(s, output),
 				stopOnFailure: r.stopOnFailure,
 				features:      []*feature{feat},
 			}
@@ -38,6 +39,7 @@ func (r *runner) concurrent(rate int) (failed bool) {
 			if suite.failed {
 				*fail = true
 			}
+			suite.fmt.Summary()
 		}(&failed, ft)
 	}
 	// wait until last are processed
@@ -46,8 +48,6 @@ func (r *runner) concurrent(rate int) (failed bool) {
 	}
 	close(queue)
 
-	// print summary
-	r.fmt.Summary()
 	return
 }
 
@@ -124,7 +124,7 @@ func RunWithOptions(suite string, contextInitializer func(suite *Suite), opt Opt
 
 	var failed bool
 	if opt.Concurrency > 1 {
-		failed = r.concurrent(opt.Concurrency)
+		failed = r.concurrent(opt.Concurrency, formatter, suite, output)
 	} else {
 		failed = r.run()
 	}

--- a/suite.go
+++ b/suite.go
@@ -163,6 +163,12 @@ func (s *Suite) AfterSuite(f func()) {
 	s.afterSuiteHandlers = append(s.afterSuiteHandlers, f)
 }
 
+// Output returns the output writer of the current formatter
+// It will not return os.Stdout but a writer used to print some delayed messages
+func (s *Suite) Output() io.Writer {
+	return s.fmt.Output()
+}
+
 func (s *Suite) run() {
 	// run before suite handlers
 	for _, f := range s.beforeSuiteHandlers {


### PR DESCRIPTION
Previously, it was not possible to print messages from an external library in godog.
Actually, it was possible, but the logs would be printed before the steps. 
- This PR adds the possibility to print these messages after the steps, this helps a lot when debugging a tests or you code.
- This PR adds the possibility to create easily external formatter as well, an example has been added in the README.
- The interface Formatter now needs to implement the method `Output()`, this method needs to return the io.writer used by the current formatter. The basent struct returns now a new struct `godog.NewDelayedMessagesWriter`, this allows the formatter to print the messages in a good order. - This is kind of similar to how the cucumber ruby version works with delayed messages.
- When running in concurrency, each suite has now its own formatter, this is way simpler to handle with concurrency, however global summary has been broken...it works as in parallel_test (ruby lib)
- DelayedMessage has only activate in the pretty format though!
