### PR TITLE
allow randomizing scenario order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change LOG
 
+**2017-04-27**
+- added an option to randomize scenario execution order, so we could
+  ensure that scenarios do not depend on global state.
+
 **2016-10-30** - **v0.6.0**
 - added experimental **events** format, this might be used for unified
   cucumber formats. But should be not adapted widely, since it is highly

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/godog"
 )
@@ -217,8 +218,9 @@ func TestMain(m *testing.M) {
 	status := godog.RunWithOptions("godogs", func(s *godog.Suite) {
 		FeatureContext(s)
 	}, godog.Options{
-		Format: "progress",
-		Paths:  []string{"features"},
+		Format:    "progress",
+		Paths:     []string{"features"},
+		Randomize: time.Now().UTC().UnixNano(), // randomize scenario execution order
 	})
 
 	if st := m.Run(); st > status {

--- a/examples/godogs/godogs_test.go
+++ b/examples/godogs/godogs_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/godog"
 )
@@ -13,8 +14,9 @@ func TestMain(m *testing.M) {
 	status := godog.RunWithOptions("godogs", func(s *godog.Suite) {
 		FeatureContext(s)
 	}, godog.Options{
-		Format: "progress",
-		Paths:  []string{"features"},
+		Format:    "progress",
+		Paths:     []string{"features"},
+		Randomize: time.Now().UTC().UnixNano(), // randomize scenario execution order
 	})
 
 	if st := m.Run(); st > status {

--- a/flags.go
+++ b/flags.go
@@ -26,6 +26,10 @@ var descTagsOption = "Filter scenarios by tags. Expression can be:\n" +
 	s(4) + "- " + colors.Yellow(`"@wip && ~@new"`) + ": run wip scenarios, but exclude new\n" +
 	s(4) + "- " + colors.Yellow(`"@wip,@undone"`) + ": run wip or undone scenarios"
 
+var descRandomOption = "Randomly shuffle the scenario execution order.\n" +
+	"Specify SEED to reproduce the shuffling from a previous run.\n" +
+	s(4) + `e.g. ` + colors.Yellow(`--random`) + " or " + colors.Yellow(`--random=5738`)
+
 // FlagSet allows to manage flags by external suite runner
 func FlagSet(opt *Options) *flag.FlagSet {
 	descFormatOption := "How to format tests output. Available formats:\n"
@@ -46,8 +50,7 @@ func FlagSet(opt *Options) *flag.FlagSet {
 	set.BoolVar(&opt.ShowStepDefinitions, "d", false, "Print all available step definitions.")
 	set.BoolVar(&opt.StopOnFailure, "stop-on-failure", false, "Stop processing on first failed scenario.")
 	set.BoolVar(&opt.NoColors, "no-colors", false, "Disable ansi colors.")
-	set.BoolVar(&opt.Randomize, "random", false, "Randomize scenario execution order.")
-	set.Int64Var(&opt.RandomSeed, "seed", 0, "Specify random seed to reproduce shuffling from a previous run.\n(implies --random)")
+	set.Var(&opt.Randomize, "random", descRandomOption)
 	set.Usage = usage(set, opt.Output)
 	return set
 }
@@ -67,12 +70,12 @@ func (f *flagged) name() string {
 		name = fmt.Sprintf("-%s", f.short)
 	}
 
-	if f.long == "seed" {
-		// `seed`` is special in that we will later assign it randomly
+	if f.long == "random" {
+		// `random` is special in that we will later assign it randomly
 		// if the user specifies `--random` without specifying one,
 		// so mask the "default" value here to avoid UI confusion about
 		// what the value will end up being.
-		name += "=SEED"
+		name += "[=SEED]"
 	} else if f.dflt != "true" && f.dflt != "false" {
 		name += "=" + f.dflt
 	}

--- a/flags.go
+++ b/flags.go
@@ -4,7 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math/rand"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/DATA-DOG/godog/colors"
 )
@@ -50,7 +53,7 @@ func FlagSet(opt *Options) *flag.FlagSet {
 	set.BoolVar(&opt.ShowStepDefinitions, "d", false, "Print all available step definitions.")
 	set.BoolVar(&opt.StopOnFailure, "stop-on-failure", false, "Stop processing on first failed scenario.")
 	set.BoolVar(&opt.NoColors, "no-colors", false, "Disable ansi colors.")
-	set.Var(&opt.Randomize, "random", descRandomOption)
+	set.Var(&randomSeed{&opt.Randomize}, "random", descRandomOption)
 	set.Usage = usage(set, opt.Output)
 	return set
 }
@@ -146,4 +149,43 @@ func usage(set *flag.FlagSet, w io.Writer) func() {
 		}
 		fmt.Fprintln(w, "")
 	}
+}
+
+// randomSeed implements `flag.Value`, see https://golang.org/pkg/flag/#Value
+type randomSeed struct {
+	ref *int64
+}
+
+// Choose randomly assigns a convenient pseudo-random seed value.
+// The resulting seed will be between `1-99999` for later ease of specification.
+func (rs *randomSeed) choose() {
+	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+	*rs.ref = r.Int63n(99998) + 1
+}
+
+func (rs *randomSeed) Set(s string) error {
+	if s == "true" {
+		rs.choose()
+		return nil
+	}
+
+	if s == "false" {
+		*rs.ref = 0
+		return nil
+	}
+
+	i, err := strconv.ParseInt(s, 10, 64)
+	*rs.ref = i
+	return err
+}
+
+func (rs randomSeed) String() string {
+	return strconv.FormatInt(*rs.ref, 10)
+}
+
+// If a Value has an IsBoolFlag() bool method returning true, the command-line
+// parser makes -name equivalent to -name=true rather than using the next
+// command-line argument.
+func (rs *randomSeed) IsBoolFlag() bool {
+	return *rs.ref == 0
 }

--- a/flags.go
+++ b/flags.go
@@ -46,6 +46,8 @@ func FlagSet(opt *Options) *flag.FlagSet {
 	set.BoolVar(&opt.ShowStepDefinitions, "d", false, "Print all available step definitions.")
 	set.BoolVar(&opt.StopOnFailure, "stop-on-failure", false, "Stop processing on first failed scenario.")
 	set.BoolVar(&opt.NoColors, "no-colors", false, "Disable ansi colors.")
+	set.BoolVar(&opt.Randomize, "random", false, "Randomize scenario execution order.")
+	set.Int64Var(&opt.RandomSeed, "seed", 0, "Specify random seed to reproduce shuffling from a previous run.\n(implies --random)")
 	set.Usage = usage(set, opt.Output)
 	return set
 }
@@ -64,7 +66,14 @@ func (f *flagged) name() string {
 	case len(f.short) > 0:
 		name = fmt.Sprintf("-%s", f.short)
 	}
-	if f.dflt != "true" && f.dflt != "false" {
+
+	if f.long == "seed" {
+		// `seed`` is special in that we will later assign it randomly
+		// if the user specifies `--random` without specifying one,
+		// so mask the "default" value here to avoid UI confusion about
+		// what the value will end up being.
+		name += "=SEED"
+	} else if f.dflt != "true" && f.dflt != "false" {
 		name += "=" + f.dflt
 	}
 	return name

--- a/fmt.go
+++ b/fmt.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -318,6 +320,13 @@ func (f *basefmt) Summary() {
 		fmt.Fprintln(f.out, fmt.Sprintf("%d steps (%s)", nsteps, strings.Join(steps, ", ")))
 	}
 	fmt.Fprintln(f.out, elapsed)
+
+	// prints used randomization seed
+	seed, err := strconv.ParseInt(os.Getenv("GODOG_SEED"), 10, 64)
+	if err == nil && seed != 0 {
+		fmt.Fprintln(f.out, "")
+		fmt.Fprintln(f.out, "Randomized with seed:", colors.Yellow(seed))
+	}
 
 	if text := f.snippets(); text != "" {
 		fmt.Fprintln(f.out, yellow("\nYou can implement step definitions for undefined steps with these snippets:"))

--- a/options.go
+++ b/options.go
@@ -13,6 +13,13 @@ type Options struct {
 	// Print step definitions found and exit
 	ShowStepDefinitions bool
 
+	// Run scenarios in random order.
+	//
+	// This is especially helpful for detecting situations
+	// where you have state leaking between scenarios, which
+	// can cause flickering or fragile tests.
+	RandomOrder bool
+
 	// Stops on the first failure
 	StopOnFailure bool
 

--- a/options.go
+++ b/options.go
@@ -13,16 +13,22 @@ type Options struct {
 	// Print step definitions found and exit
 	ShowStepDefinitions bool
 
-	// RandomSeed, if not `0`, will be used to run scenarios in a random order.
+	// Randomize causes scenarios to be run in random order.
 	//
 	// Randomizing scenario order is especially helpful for detecting
 	// situations where you have state leaking between scenarios, which can
 	// cause flickering or fragile tests.
+	Randomize bool
+
+	// RandomSeed allows specifying the seed to reproduce the random scenario
+	// shuffling from a previous run.
 	//
-	// The default value of `0` means "do not randomize".
+	// When `RandomSeed` is left at the nil value (`0`), but `Randomize`
+	// has been set to `true`, then godog will automatically pick a random
+	// seed between `1-99999` for ease of specification.
 	//
-	// The magic value of `-1` means "pick a random seed for me", the resulting
-	// seed will only be between `1-99999` for ease of specification.
+	// If RandomSeed is set to anything other than the default nil value (`0`),
+	// then `Randomize = true` will be implied.
 	RandomSeed int64
 
 	// Stops on the first failure

--- a/options.go
+++ b/options.go
@@ -13,12 +13,17 @@ type Options struct {
 	// Print step definitions found and exit
 	ShowStepDefinitions bool
 
-	// Run scenarios in random order.
+	// RandomSeed, if not `0`, will be used to run scenarios in a random order.
 	//
-	// This is especially helpful for detecting situations
-	// where you have state leaking between scenarios, which
-	// can cause flickering or fragile tests.
-	RandomOrder bool
+	// Randomizing scenario order is especially helpful for detecting
+	// situations where you have state leaking between scenarios, which can
+	// cause flickering or fragile tests.
+	//
+	// The default value of `0` means "do not randomize".
+	//
+	// The magic value of `-1` means "pick a random seed for me", the resulting
+	// seed will only be between `1-99999` for ease of specification.
+	RandomSeed int64
 
 	// Stops on the first failure
 	StopOnFailure bool

--- a/options.go
+++ b/options.go
@@ -2,9 +2,6 @@ package godog
 
 import (
 	"io"
-	"math/rand"
-	"strconv"
-	"time"
 )
 
 // Options are suite run options
@@ -33,7 +30,7 @@ type Options struct {
 	// Any other value will be used as the random seed for shuffling. Re-using the
 	// same seed will allow you to reproduce the shuffle order of a previous run
 	// to isolate an error condition.
-	Randomize randomSeed
+	Randomize int64
 
 	// Stops on the first failure
 	StopOnFailure bool
@@ -56,41 +53,4 @@ type Options struct {
 
 	// Where it should print formatter output
 	Output io.Writer
-}
-
-// randomSeed implements `flag.Value`, see https://golang.org/pkg/flag/#Value
-type randomSeed int64
-
-// Choose randomly assigns a convenient pseudo-random seed value.
-// The resulting seed will be between `1-99999` for later ease of specification.
-func (rs *randomSeed) Choose() {
-	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
-	*rs = randomSeed(r.Int63n(99998) + 1)
-}
-
-func (rs *randomSeed) Set(s string) error {
-	if s == "true" {
-		rs.Choose()
-		return nil
-	}
-
-	if s == "false" {
-		*rs = 0
-		return nil
-	}
-
-	i, err := strconv.ParseInt(s, 10, 64)
-	*rs = randomSeed(i)
-	return err
-}
-
-func (rs randomSeed) String() string {
-	return strconv.FormatInt(int64(rs), 10)
-}
-
-// If a Value has an IsBoolFlag() bool method returning true, the command-line
-// parser makes -name equivalent to -name=true rather than using the next
-// command-line argument.
-func (rs *randomSeed) IsBoolFlag() bool {
-	return *rs == 0
 }

--- a/options.go
+++ b/options.go
@@ -1,6 +1,11 @@
 package godog
 
-import "io"
+import (
+	"io"
+	"math/rand"
+	"strconv"
+	"time"
+)
 
 // Options are suite run options
 // flags are mapped to these options.
@@ -13,23 +18,22 @@ type Options struct {
 	// Print step definitions found and exit
 	ShowStepDefinitions bool
 
-	// Randomize causes scenarios to be run in random order.
+	// Randomize, if not `0`, will be used to run scenarios in a random order.
 	//
 	// Randomizing scenario order is especially helpful for detecting
 	// situations where you have state leaking between scenarios, which can
 	// cause flickering or fragile tests.
-	Randomize bool
-
-	// RandomSeed allows specifying the seed to reproduce the random scenario
-	// shuffling from a previous run.
 	//
-	// When `RandomSeed` is left at the nil value (`0`), but `Randomize`
-	// has been set to `true`, then godog will automatically pick a random
-	// seed between `1-99999` for ease of specification.
+	// The default value of `0` means "do not randomize".
 	//
-	// If RandomSeed is set to anything other than the default nil value (`0`),
-	// then `Randomize = true` will be implied.
-	RandomSeed int64
+	// The magic value of `-1` means "pick a random seed for me", and godog will
+	// assign a seed on it's own during the `RunWithOptions` phase, similar to if
+	// you specified `--random` on the command line.
+	//
+	// Any other value will be used as the random seed for shuffling. Re-using the
+	// same seed will allow you to reproduce the shuffle order of a previous run
+	// to isolate an error condition.
+	Randomize randomSeed
 
 	// Stops on the first failure
 	StopOnFailure bool
@@ -52,4 +56,41 @@ type Options struct {
 
 	// Where it should print formatter output
 	Output io.Writer
+}
+
+// randomSeed implements `flag.Value`, see https://golang.org/pkg/flag/#Value
+type randomSeed int64
+
+// Choose randomly assigns a convenient pseudo-random seed value.
+// The resulting seed will be between `1-99999` for later ease of specification.
+func (rs *randomSeed) Choose() {
+	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+	*rs = randomSeed(r.Int63n(99998) + 1)
+}
+
+func (rs *randomSeed) Set(s string) error {
+	if s == "true" {
+		rs.Choose()
+		return nil
+	}
+
+	if s == "false" {
+		*rs = 0
+		return nil
+	}
+
+	i, err := strconv.ParseInt(s, 10, 64)
+	*rs = randomSeed(i)
+	return err
+}
+
+func (rs randomSeed) String() string {
+	return strconv.FormatInt(int64(rs), 10)
+}
+
+// If a Value has an IsBoolFlag() bool method returning true, the command-line
+// parser makes -name equivalent to -name=true rather than using the next
+// command-line argument.
+func (rs *randomSeed) IsBoolFlag() bool {
+	return *rs == 0
 }

--- a/run.go
+++ b/run.go
@@ -3,9 +3,7 @@ package godog
 import (
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/DATA-DOG/godog/colors"
 )
@@ -111,23 +109,17 @@ func RunWithOptions(suite string, contextInitializer func(suite *Suite), opt Opt
 	features, err := parseFeatures(opt.Tags, opt.Paths)
 	fatal(err)
 
-	// the actual seed value which will be propogated
-	// if left as nil value, then scenarios run sequentially
-	var seed int64
-	// use specified seed if exists, or assign one ourselves if
-	// none specified but user wants randomization
-	if opt.RandomSeed != 0 {
-		seed = opt.RandomSeed
-	} else if opt.Randomize && opt.RandomSeed == 0 {
-		r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
-		seed = r.Int63n(99998) + 1
+	// handle convenience condition where user specified `-1` in Options struct,
+	// asking us to choose the random value seed for them.
+	if opt.Randomize == -1 {
+		opt.Randomize.Choose()
 	}
 
 	r := runner{
 		fmt:           formatter(suite, output),
 		initializer:   contextInitializer,
 		features:      features,
-		randomSeed:    seed,
+		randomSeed:    int64(opt.Randomize),
 		stopOnFailure: opt.StopOnFailure,
 	}
 

--- a/run.go
+++ b/run.go
@@ -111,10 +111,14 @@ func RunWithOptions(suite string, contextInitializer func(suite *Suite), opt Opt
 	features, err := parseFeatures(opt.Tags, opt.Paths)
 	fatal(err)
 
-	seed := opt.RandomSeed
-	if seed == -1 {
-		// if RandomSeed opt is -1, means pick a memorable rand seed as default
-		// the docStrings for Option specify this should be 1-99999 (same as ruby Cucumber)
+	// the actual seed value which will be propogated
+	// if left as nil value, then scenarios run sequentially
+	var seed int64
+	// use specified seed if exists, or assign one ourselves if
+	// none specified but user wants randomization
+	if opt.RandomSeed != 0 {
+		seed = opt.RandomSeed
+	} else if opt.Randomize && opt.RandomSeed == 0 {
 		r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 		seed = r.Int63n(99998) + 1
 	}

--- a/run.go
+++ b/run.go
@@ -118,10 +118,6 @@ func RunWithOptions(suite string, contextInitializer func(suite *Suite), opt Opt
 		r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 		seed = r.Int63n(99998) + 1
 	}
-	if seed != 0 {
-		// init global rand module (concurrent safe) with our seed
-		rand.Seed(seed)
-	}
 
 	r := runner{
 		fmt:           formatter(suite, output),

--- a/run.go
+++ b/run.go
@@ -3,7 +3,9 @@ package godog
 import (
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/DATA-DOG/godog/colors"
 )
@@ -11,6 +13,7 @@ import (
 type initializer func(*Suite)
 
 type runner struct {
+	randomOrder   bool
 	stopOnFailure bool
 	features      []*feature
 	fmt           Formatter
@@ -30,6 +33,7 @@ func (r *runner) concurrent(rate int) (failed bool) {
 			}
 			suite := &Suite{
 				fmt:           r.fmt,
+				randomOrder:   r.randomOrder,
 				stopOnFailure: r.stopOnFailure,
 				features:      []*feature{feat},
 			}
@@ -54,6 +58,7 @@ func (r *runner) concurrent(rate int) (failed bool) {
 func (r *runner) run() (failed bool) {
 	suite := &Suite{
 		fmt:           r.fmt,
+		randomOrder:   r.randomOrder,
 		stopOnFailure: r.stopOnFailure,
 		features:      r.features,
 	}
@@ -110,7 +115,14 @@ func RunWithOptions(suite string, contextInitializer func(suite *Suite), opt Opt
 		fmt:           formatter(suite, output),
 		initializer:   contextInitializer,
 		features:      features,
+		randomOrder:   opt.RandomOrder,
 		stopOnFailure: opt.StopOnFailure,
+	}
+
+	if opt.RandomOrder {
+		// TODO(mroth): allow for seed to be specified in options,
+		// and print it at the end of a run for replication purposes
+		rand.Seed(time.Now().UTC().UnixNano())
 	}
 
 	var failed bool

--- a/run.go
+++ b/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/DATA-DOG/godog/colors"
 )
@@ -109,19 +110,16 @@ func RunWithOptions(suite string, contextInitializer func(suite *Suite), opt Opt
 	features, err := parseFeatures(opt.Tags, opt.Paths)
 	fatal(err)
 
-	// handle convenience condition where user specified `-1` in Options struct,
-	// asking us to choose the random value seed for them.
-	if opt.Randomize == -1 {
-		opt.Randomize.Choose()
-	}
-
 	r := runner{
 		fmt:           formatter(suite, output),
 		initializer:   contextInitializer,
 		features:      features,
-		randomSeed:    int64(opt.Randomize),
+		randomSeed:    opt.Randomize,
 		stopOnFailure: opt.StopOnFailure,
 	}
+
+	// store chosen seed in environment, so it could be seen in formatter summary report
+	os.Setenv("GODOG_SEED", strconv.FormatInt(r.randomSeed, 10))
 
 	var failed bool
 	if opt.Concurrency > 1 {

--- a/suite.go
+++ b/suite.go
@@ -50,7 +50,7 @@ type Suite struct {
 	fmt      Formatter
 
 	failed        bool
-	randomOrder   bool
+	randomSeed    int64
 	stopOnFailure bool
 
 	// suite event handlers
@@ -336,7 +336,7 @@ func (s *Suite) runFeature(f *feature) {
 	// make a local copy of the feature scenario defenitions,
 	// then shuffle it if we are randomizing scenarios
 	scenarios := make([]interface{}, len(f.ScenarioDefinitions))
-	if s.randomOrder {
+	if s.randomSeed != 0 {
 		perm := rand.Perm(len(f.ScenarioDefinitions))
 		for i, v := range perm {
 			scenarios[v] = f.ScenarioDefinitions[i]

--- a/suite.go
+++ b/suite.go
@@ -337,7 +337,8 @@ func (s *Suite) runFeature(f *feature) {
 	// then shuffle it if we are randomizing scenarios
 	scenarios := make([]interface{}, len(f.ScenarioDefinitions))
 	if s.randomSeed != 0 {
-		perm := rand.Perm(len(f.ScenarioDefinitions))
+		r := rand.New(rand.NewSource(s.randomSeed))
+		perm := r.Perm(len(f.ScenarioDefinitions))
 		for i, v := range perm {
 			scenarios[v] = f.ScenarioDefinitions[i]
 		}

--- a/suite.go
+++ b/suite.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -49,6 +50,7 @@ type Suite struct {
 	fmt      Formatter
 
 	failed        bool
+	randomOrder   bool
 	stopOnFailure bool
 
 	// suite event handlers
@@ -330,7 +332,20 @@ func (s *Suite) runOutline(outline *gherkin.ScenarioOutline, b *gherkin.Backgrou
 
 func (s *Suite) runFeature(f *feature) {
 	s.fmt.Feature(f.Feature, f.Path, f.Content)
-	for _, scenario := range f.ScenarioDefinitions {
+
+	// make a local copy of the feature scenario defenitions,
+	// then shuffle it if we are randomizing scenarios
+	scenarios := make([]interface{}, len(f.ScenarioDefinitions))
+	if s.randomOrder {
+		perm := rand.Perm(len(f.ScenarioDefinitions))
+		for i, v := range perm {
+			scenarios[v] = f.ScenarioDefinitions[i]
+		}
+	} else {
+		copy(scenarios, f.ScenarioDefinitions)
+	}
+
+	for _, scenario := range scenarios {
 		var err error
 		if f.Background != nil {
 			s.fmt.Node(f.Background)


### PR DESCRIPTION
*WORK IN PROGRESS FOR DISCUSSION, NOT READY TO MERGE*

## Summary

Allow running scenarios in random order.

> This is especially helpful for detecting situations where you have state leaking between scenarios, which can cause flickering or fragile tests.

Similar to: https://www.relishapp.com/cucumber/cucumber/docs/cli/randomize

## Discussion
This isn't quite ready, but I wanted to open it for discussion with the maintainers prior to doing too much work on it.

## TODO
If this was to be adopted, the following would likely need to be done at minimum before merging:

1. Add some sort of `--random` flag to CLI app (will leave it up to maintainers to decide what the ideal name would be?)
2. update `--help` documentation to reflect/explain this flag.

Additionally, the following might be desirable:

1. Print the random seed at the end of a test run
2. Allow random seed to be specified via a command line `--flag` of some sort
3. Integration tests? (not quite sure how that would be implemented) 