### PR TITLE
implements convenient multistep definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change LOG
 
+**2017-04-29**
+- added support for nested steps. From now on, it is possible to return
+  **godog.Steps** instead of an **error** in the step definition func.
+  This change introduced few minor changes in **Formatter** interface. Be
+  sure to adapt the changes if you have custom formatters.
+
 **2017-04-27**
 - added an option to randomize scenario execution order, so we could
   ensure that scenarios do not depend on global state.

--- a/README.md
+++ b/README.md
@@ -248,8 +248,11 @@ See implementation examples:
 
 ### FAQ
 
-**Q:** Where can I configure common options globally?
-**A:** You can't. Alias your common or project based commands: `alias godog-wip="godog --format=progress --tags=@wip"`
+#### Configure common options for godog CLI
+
+There are no global options or configuration files. Alias your common or
+project based commands: `alias godog-wip="godog --format=progress
+--tags=@wip"`
 
 ### Contributions
 

--- a/examples/api/version.feature
+++ b/examples/api/version.feature
@@ -20,6 +20,6 @@ Feature: get version
     And the response should match json:
       """
       {
-        "version": "v0.6.3"
+        "version": "v0.7.0"
       }
       """

--- a/features/formatter/events.feature
+++ b/features/formatter/events.feature
@@ -14,7 +14,7 @@ Feature: event stream formatter
       """
 
   Scenario: should process simple scenario
-    Given a feature path "features/load.feature:22"
+    Given a feature path "features/load.feature:23"
     When I run feature suite with formatter "events"
     Then the following events should be fired:
       """
@@ -35,7 +35,7 @@ Feature: event stream formatter
       """
 
   Scenario: should process outline scenario
-    Given a feature path "features/load.feature:30"
+    Given a feature path "features/load.feature:31"
     When I run feature suite with formatter "events"
     Then the following events should be fired:
       """

--- a/features/lang.feature
+++ b/features/lang.feature
@@ -8,7 +8,7 @@ Savybė: užkrauti savybes
   Scenarijus: savybių užkrovimas iš aplanko
     Duota savybių aplankas "features"
     Kai aš išskaitau savybes
-    Tada aš turėčiau turėti 9 savybių failus:
+    Tada aš turėčiau turėti 10 savybių failus:
       """
       features/background.feature
       features/events.feature
@@ -16,6 +16,7 @@ Savybė: užkrauti savybes
       features/formatter/events.feature
       features/lang.feature
       features/load.feature
+      features/multistep.feature
       features/outline.feature
       features/run.feature
       features/snippets.feature

--- a/features/load.feature
+++ b/features/load.feature
@@ -6,7 +6,7 @@ Feature: load features
   Scenario: load features within path
     Given a feature path "features"
     When I parse features
-    Then I should have 9 feature files:
+    Then I should have 10 feature files:
       """
       features/background.feature
       features/events.feature
@@ -14,6 +14,7 @@ Feature: load features
       features/formatter/events.feature
       features/lang.feature
       features/load.feature
+      features/multistep.feature
       features/outline.feature
       features/run.feature
       features/snippets.feature

--- a/features/multistep.feature
+++ b/features/multistep.feature
@@ -1,0 +1,140 @@
+Feature: run features with nested steps
+  In order to test multisteps
+  As a test suite
+  I need to be able to execute multisteps
+
+  Scenario: should run passing multistep successfully
+    Given a feature "normal.feature" file:
+      """
+      Feature: normal feature
+
+        Scenario: run passing multistep
+          Given passing step
+          Then passing multistep
+      """
+    When I run feature suite
+    Then the suite should have passed
+    And the following steps should be passed:
+      """
+      passing step
+      passing multistep
+      """
+
+  Scenario: should fail multistep
+    Given a feature "failed.feature" file:
+      """
+      Feature: failed feature
+
+        Scenario: run failing multistep
+          Given passing step
+          When failing multistep
+          Then I should have 1 scenario registered
+      """
+    When I run feature suite
+    Then the suite should have failed
+    And the following step should be failed:
+      """
+      failing multistep
+      """
+    And the following steps should be skipped:
+      """
+      I should have 1 scenario registered
+      """
+    And the following steps should be passed:
+      """
+      passing step
+      """
+
+  Scenario: should fail nested multistep
+    Given a feature "failed.feature" file:
+      """
+      Feature: failed feature
+
+        Scenario: run failing nested multistep
+          Given failing nested multistep
+          When passing step
+      """
+    When I run feature suite
+    Then the suite should have failed
+    And the following step should be failed:
+      """
+      failing nested multistep
+      """
+    And the following steps should be skipped:
+      """
+      passing step
+      """
+
+  Scenario: should skip steps after undefined multistep
+    Given a feature "undefined.feature" file:
+      """
+      Feature: run undefined multistep
+
+        Scenario: run undefined multistep
+          Given passing step
+          When undefined multistep
+          Then passing multistep
+      """
+    When I run feature suite
+    Then the suite should have passed
+    And the following step should be passed:
+      """
+      passing step
+      """
+    And the following step should be undefined:
+      """
+      undefined multistep
+      """
+    And the following step should be skipped:
+      """
+      passing multistep
+      """
+
+  Scenario: should match undefined steps in a row
+    Given a feature "undefined.feature" file:
+      """
+      Feature: undefined feature
+
+        Scenario: parse a scenario
+          Given undefined step
+          When undefined multistep
+          Then I should have 1 scenario registered
+      """
+    When I run feature suite
+    Then the suite should have passed
+    And the following steps should be undefined:
+      """
+      undefined step
+      undefined multistep
+      """
+    And the following step should be skipped:
+      """
+      I should have 1 scenario registered
+      """
+
+  Scenario: should mark undefined steps after pending
+    Given a feature "pending.feature" file:
+      """
+      Feature: pending feature
+
+        Scenario: parse a scenario
+          Given pending step
+          When undefined step
+          Then undefined multistep
+          And I should have 1 scenario registered
+      """
+    When I run feature suite
+    Then the suite should have passed
+    And the following steps should be undefined:
+      """
+      undefined step
+      undefined multistep
+      """
+    And the following step should be pending:
+      """
+      pending step
+      """
+    And the following step should be skipped:
+      """
+      I should have 1 scenario registered
+      """

--- a/fmt.go
+++ b/fmt.go
@@ -105,8 +105,8 @@ type Formatter interface {
 	Defined(*gherkin.Step, *StepDef)
 	Failed(*gherkin.Step, *StepDef, error)
 	Passed(*gherkin.Step, *StepDef)
-	Skipped(*gherkin.Step)
-	Undefined(*gherkin.Step)
+	Skipped(*gherkin.Step, *StepDef)
+	Undefined(*gherkin.Step, *StepDef)
 	Pending(*gherkin.Step, *StepDef)
 	Summary()
 }
@@ -210,21 +210,23 @@ func (f *basefmt) Passed(step *gherkin.Step, match *StepDef) {
 	f.passed = append(f.passed, s)
 }
 
-func (f *basefmt) Skipped(step *gherkin.Step) {
+func (f *basefmt) Skipped(step *gherkin.Step, match *StepDef) {
 	s := &stepResult{
 		owner:   f.owner,
 		feature: f.features[len(f.features)-1],
 		step:    step,
+		def:     match,
 		typ:     skipped,
 	}
 	f.skipped = append(f.skipped, s)
 }
 
-func (f *basefmt) Undefined(step *gherkin.Step) {
+func (f *basefmt) Undefined(step *gherkin.Step, match *StepDef) {
 	s := &stepResult{
 		owner:   f.owner,
 		feature: f.features[len(f.features)-1],
 		step:    step,
+		def:     match,
 		typ:     undefined,
 	}
 	f.undefined = append(f.undefined, s)
@@ -394,38 +396,46 @@ func (f *basefmt) snippets() string {
 	var snips []*undefinedSnippet
 	// build snippets
 	for _, u := range f.undefined {
-		expr := snippetExprCleanup.ReplaceAllString(u.step.Text, "\\$1")
-		expr = snippetNumbers.ReplaceAllString(expr, "(\\d+)")
-		expr = snippetExprQuoted.ReplaceAllString(expr, "$1\"([^\"]*)\"$2")
-		expr = "^" + strings.TrimSpace(expr) + "$"
+		steps := []string{u.step.Text}
+		arg := u.step.Argument
+		if u.def != nil {
+			steps = u.def.undefined
+			arg = nil
+		}
+		for _, step := range steps {
+			expr := snippetExprCleanup.ReplaceAllString(step, "\\$1")
+			expr = snippetNumbers.ReplaceAllString(expr, "(\\d+)")
+			expr = snippetExprQuoted.ReplaceAllString(expr, "$1\"([^\"]*)\"$2")
+			expr = "^" + strings.TrimSpace(expr) + "$"
 
-		name := snippetNumbers.ReplaceAllString(u.step.Text, " ")
-		name = snippetExprQuoted.ReplaceAllString(name, " ")
-		name = snippetMethodName.ReplaceAllString(name, "")
-		var words []string
-		for i, w := range strings.Split(name, " ") {
-			if i != 0 {
-				w = strings.Title(w)
-			} else {
-				w = string(unicode.ToLower(rune(w[0]))) + w[1:]
+			name := snippetNumbers.ReplaceAllString(step, " ")
+			name = snippetExprQuoted.ReplaceAllString(name, " ")
+			name = snippetMethodName.ReplaceAllString(name, "")
+			var words []string
+			for i, w := range strings.Split(name, " ") {
+				if i != 0 {
+					w = strings.Title(w)
+				} else {
+					w = string(unicode.ToLower(rune(w[0]))) + w[1:]
+				}
+				words = append(words, w)
 			}
-			words = append(words, w)
-		}
-		name = strings.Join(words, "")
-		if len(name) == 0 {
-			index++
-			name = fmt.Sprintf("stepDefinition%d", index)
-		}
+			name = strings.Join(words, "")
+			if len(name) == 0 {
+				index++
+				name = fmt.Sprintf("stepDefinition%d", index)
+			}
 
-		var found bool
-		for _, snip := range snips {
-			if snip.Expr == expr {
-				found = true
-				break
+			var found bool
+			for _, snip := range snips {
+				if snip.Expr == expr {
+					found = true
+					break
+				}
 			}
-		}
-		if !found {
-			snips = append(snips, &undefinedSnippet{Method: name, Expr: expr, argument: u.step.Argument})
+			if !found {
+				snips = append(snips, &undefinedSnippet{Method: name, Expr: expr, argument: arg})
+			}
 		}
 	}
 

--- a/fmt_cucumber.go
+++ b/fmt_cucumber.go
@@ -297,16 +297,16 @@ func (f *cukefmt) Passed(step *gherkin.Step, match *StepDef) {
 	f.step(f.passed[len(f.passed)-1])
 }
 
-func (f *cukefmt) Skipped(step *gherkin.Step) {
-	f.basefmt.Skipped(step)
+func (f *cukefmt) Skipped(step *gherkin.Step, match *StepDef) {
+	f.basefmt.Skipped(step, match)
 	f.step(f.skipped[len(f.skipped)-1])
 
 	// no duration reported for skipped.
 	f.curStep.Result.Duration = nil
 }
 
-func (f *cukefmt) Undefined(step *gherkin.Step) {
-	f.basefmt.Undefined(step)
+func (f *cukefmt) Undefined(step *gherkin.Step, match *StepDef) {
+	f.basefmt.Undefined(step, match)
 	f.stat = undefined
 	f.step(f.undefined[len(f.undefined)-1])
 

--- a/fmt_events.go
+++ b/fmt_events.go
@@ -245,13 +245,13 @@ func (f *events) Passed(step *gherkin.Step, match *StepDef) {
 	f.step(f.passed[len(f.passed)-1])
 }
 
-func (f *events) Skipped(step *gherkin.Step) {
-	f.basefmt.Skipped(step)
+func (f *events) Skipped(step *gherkin.Step, match *StepDef) {
+	f.basefmt.Skipped(step, match)
 	f.step(f.skipped[len(f.skipped)-1])
 }
 
-func (f *events) Undefined(step *gherkin.Step) {
-	f.basefmt.Undefined(step)
+func (f *events) Undefined(step *gherkin.Step, match *StepDef) {
+	f.basefmt.Undefined(step, match)
 	f.stat = undefined
 	f.step(f.undefined[len(f.undefined)-1])
 }

--- a/fmt_junit.go
+++ b/fmt_junit.go
@@ -101,7 +101,7 @@ func (j *junitFormatter) Passed(step *gherkin.Step, match *StepDef) {
 	tcase.Status = "passed"
 }
 
-func (j *junitFormatter) Skipped(step *gherkin.Step) {
+func (j *junitFormatter) Skipped(step *gherkin.Step, match *StepDef) {
 	suite := j.current()
 
 	tcase := suite.current()
@@ -112,7 +112,7 @@ func (j *junitFormatter) Skipped(step *gherkin.Step) {
 	})
 }
 
-func (j *junitFormatter) Undefined(step *gherkin.Step) {
+func (j *junitFormatter) Undefined(step *gherkin.Step, match *StepDef) {
 	suite := j.current()
 	tcase := suite.current()
 	if tcase.Status != "undefined" {

--- a/fmt_pretty.go
+++ b/fmt_pretty.go
@@ -334,13 +334,13 @@ func (f *pretty) Passed(step *gherkin.Step, match *StepDef) {
 	f.printStepKind(f.passed[len(f.passed)-1])
 }
 
-func (f *pretty) Skipped(step *gherkin.Step) {
-	f.basefmt.Skipped(step)
+func (f *pretty) Skipped(step *gherkin.Step, match *StepDef) {
+	f.basefmt.Skipped(step, match)
 	f.printStepKind(f.skipped[len(f.skipped)-1])
 }
 
-func (f *pretty) Undefined(step *gherkin.Step) {
-	f.basefmt.Undefined(step)
+func (f *pretty) Undefined(step *gherkin.Step, match *StepDef) {
+	f.basefmt.Undefined(step, match)
 	f.printStepKind(f.undefined[len(f.undefined)-1])
 }
 

--- a/fmt_progress.go
+++ b/fmt_progress.go
@@ -91,17 +91,17 @@ func (f *progress) Passed(step *gherkin.Step, match *StepDef) {
 	f.step(f.passed[len(f.passed)-1])
 }
 
-func (f *progress) Skipped(step *gherkin.Step) {
+func (f *progress) Skipped(step *gherkin.Step, match *StepDef) {
 	f.Lock()
 	defer f.Unlock()
-	f.basefmt.Skipped(step)
+	f.basefmt.Skipped(step, match)
 	f.step(f.skipped[len(f.skipped)-1])
 }
 
-func (f *progress) Undefined(step *gherkin.Step) {
+func (f *progress) Undefined(step *gherkin.Step, match *StepDef) {
 	f.Lock()
 	defer f.Unlock()
-	f.basefmt.Undefined(step)
+	f.basefmt.Undefined(step, match)
 	f.step(f.undefined[len(f.undefined)-1])
 }
 

--- a/fmt_progress_test.go
+++ b/fmt_progress_test.go
@@ -92,8 +92,8 @@ var basicGherkinFeature = `
 Feature: basic
 
   Scenario: passing scenario
-	When step1
-	Then step2
+	When one
+	Then two
 `
 
 func TestProgressFormatterWhenStepPanics(t *testing.T) {
@@ -108,8 +108,8 @@ func TestProgressFormatterWhenStepPanics(t *testing.T) {
 		fmt:      progressFunc("progress", w),
 		features: []*feature{&feature{Feature: feat}},
 		initializer: func(s *Suite) {
-			s.Step(`^step1$`, func() error { return nil })
-			s.Step(`^step2$`, func() error { panic("omg") })
+			s.Step(`^one$`, func() error { return nil })
+			s.Step(`^two$`, func() error { panic("omg") })
 		},
 	}
 
@@ -137,9 +137,9 @@ func TestProgressFormatterWithPassingMultisteps(t *testing.T) {
 		initializer: func(s *Suite) {
 			s.Step(`^sub1$`, func() error { return nil })
 			s.Step(`^sub-sub$`, func() error { return nil })
-			s.Step(`^sub2$`, func() Steps { return Steps{"sub-sub", "sub1", "step1"} })
-			s.Step(`^step1$`, func() error { return nil })
-			s.Step(`^step2$`, func() Steps { return Steps{"sub1", "sub2"} })
+			s.Step(`^sub2$`, func() Steps { return Steps{"sub-sub", "sub1", "one"} })
+			s.Step(`^one$`, func() error { return nil })
+			s.Step(`^two$`, func() Steps { return Steps{"sub1", "sub2"} })
 		},
 	}
 
@@ -162,9 +162,9 @@ func TestProgressFormatterWithFailingMultisteps(t *testing.T) {
 		initializer: func(s *Suite) {
 			s.Step(`^sub1$`, func() error { return nil })
 			s.Step(`^sub-sub$`, func() error { return fmt.Errorf("errored") })
-			s.Step(`^sub2$`, func() Steps { return Steps{"sub-sub", "sub1", "step1"} })
-			s.Step(`^step1$`, func() error { return nil })
-			s.Step(`^step2$`, func() Steps { return Steps{"sub1", "sub2"} })
+			s.Step(`^sub2$`, func() Steps { return Steps{"sub-sub", "sub1", "one"} })
+			s.Step(`^one$`, func() error { return nil })
+			s.Step(`^two$`, func() Steps { return Steps{"sub1", "sub2"} })
 		},
 	}
 
@@ -187,13 +187,77 @@ func TestProgressFormatterWithPanicInMultistep(t *testing.T) {
 		initializer: func(s *Suite) {
 			s.Step(`^sub1$`, func() error { return nil })
 			s.Step(`^sub-sub$`, func() error { return nil })
-			s.Step(`^sub2$`, func() []string { return []string{"sub-sub", "sub1", "step1"} })
-			s.Step(`^step1$`, func() error { return nil })
-			s.Step(`^step2$`, func() []string { return []string{"sub1", "sub2"} })
+			s.Step(`^sub2$`, func() []string { return []string{"sub-sub", "sub1", "one"} })
+			s.Step(`^one$`, func() error { return nil })
+			s.Step(`^two$`, func() []string { return []string{"sub1", "sub2"} })
 		},
 	}
 
 	if !r.run() {
 		t.Fatal("the suite should have failed")
+	}
+}
+
+func TestProgressFormatterMultistepTemplates(t *testing.T) {
+	feat, err := gherkin.ParseFeature(strings.NewReader(basicGherkinFeature))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	w := colors.Uncolored(&buf)
+	r := runner{
+		fmt:      progressFunc("progress", w),
+		features: []*feature{&feature{Feature: feat}},
+		initializer: func(s *Suite) {
+			s.Step(`^sub-sub$`, func() error { return nil })
+			s.Step(`^substep$`, func() Steps { return Steps{"sub-sub", `unavailable "John" cost 5`, "one", "three"} })
+			s.Step(`^one$`, func() error { return nil })
+			s.Step(`^(t)wo$`, func(s string) Steps { return Steps{"undef", "substep"} })
+		},
+	}
+
+	if r.run() {
+		t.Fatal("the suite should have passed")
+	}
+
+	expected := `
+.U 2
+
+
+1 scenarios (1 undefined)
+2 steps (1 passed, 1 undefined)
+%s
+
+Randomized with seed: %s
+
+You can implement step definitions for undefined steps with these snippets:
+
+func undef() error {
+	return godog.ErrPending
+}
+
+func unavailableCost(arg1 string, arg2 int) error {
+	return godog.ErrPending
+}
+
+func three() error {
+	return godog.ErrPending
+}
+
+func FeatureContext(s *godog.Suite) {
+	s.Step(` + "`^undef$`" + `, undef)
+	s.Step(` + "`^unavailable \"([^\"]*)\" cost (\\d+)$`" + `, unavailableCost)
+	s.Step(` + "`^three$`" + `, three)
+}
+`
+
+	var zeroDuration time.Duration
+	expected = fmt.Sprintf(expected, zeroDuration.String(), os.Getenv("GODOG_SEED"))
+	expected = trimAllLines(expected)
+
+	actual := trimAllLines(buf.String())
+	if actual != expected {
+		t.Fatalf("expected output does not match: %s", actual)
 	}
 }

--- a/godog.go
+++ b/godog.go
@@ -42,4 +42,4 @@ Godog was inspired by Behat and Cucumber the above description is taken from it'
 package godog
 
 // Version of package - based on Semantic Versioning 2.0.0 http://semver.org/
-const Version = "v0.6.3"
+const Version = "v0.7.0"

--- a/run.go
+++ b/run.go
@@ -54,7 +54,7 @@ func (r *runner) concurrent(rate int) (failed bool) {
 	return
 }
 
-func (r *runner) run() (failed bool) {
+func (r *runner) run() bool {
 	suite := &Suite{
 		fmt:           r.fmt,
 		randomSeed:    r.randomSeed,

--- a/run.go
+++ b/run.go
@@ -160,13 +160,11 @@ func Run(suite string, contextInitializer func(suite *Suite)) int {
 func supportsConcurrency(format string) bool {
 	switch format {
 	case "events":
-		return false
 	case "junit":
-		return false
 	case "pretty":
-		return false
 	case "cucumber":
-		return false
+	default:
+		return true // supports concurrency
 	}
 
 	return true // all custom formatters are treated as supporting concurrency

--- a/stepdef.go
+++ b/stepdef.go
@@ -53,7 +53,7 @@ func (sd *StepDef) definitionID() string {
 
 // run a step with the matched arguments using
 // reflect
-func (sd *StepDef) run() error {
+func (sd *StepDef) run() interface{} {
 	typ := sd.hv.Type()
 	if len(sd.args) < typ.NumIn() {
 		return fmt.Errorf("func expects %d arguments, which is more than %d matched from step", typ.NumIn(), len(sd.args))
@@ -171,12 +171,7 @@ func (sd *StepDef) run() error {
 			return fmt.Errorf("the argument %d type %s is not supported", i, param.Kind())
 		}
 	}
-	ret := sd.hv.Call(values)[0].Interface()
-	if nil == ret {
-		return nil
-	}
-
-	return ret.(error)
+	return sd.hv.Call(values)[0].Interface()
 }
 
 func (sd *StepDef) shouldBeString(idx int) (string, error) {

--- a/stepdef.go
+++ b/stepdef.go
@@ -43,7 +43,10 @@ type StepDef struct {
 	hv      reflect.Value
 	Expr    *regexp.Regexp
 	Handler interface{}
-	nested  bool
+
+	// multistep related
+	nested    bool
+	undefined []string
 }
 
 func (sd *StepDef) definitionID() string {

--- a/stepdef.go
+++ b/stepdef.go
@@ -14,6 +14,22 @@ import (
 
 var matchFuncDefRef = regexp.MustCompile(`\(([^\)]+)\)`)
 
+// Steps allows to nest steps
+// instead of returning an error in step func
+// it is possible to return combined steps:
+//
+//   func multistep(name string) godog.Steps {
+//     return godog.Steps{
+//       fmt.Sprintf(`an user named "%s"`, name),
+//       fmt.Sprintf(`user "%s" is authenticated`, name),
+//     }
+//   }
+//
+// These steps will be matched and executed in
+// sequential order. The first one which fails
+// will result in main step failure.
+type Steps []string
+
 // StepDef is a registered step definition
 // contains a StepHandler and regexp which
 // is used to match a step. Args which
@@ -27,6 +43,7 @@ type StepDef struct {
 	hv      reflect.Value
 	Expr    *regexp.Regexp
 	Handler interface{}
+	nested  bool
 }
 
 func (sd *StepDef) definitionID() string {

--- a/suite_test.go
+++ b/suite_test.go
@@ -20,21 +20,28 @@ func TestMain(m *testing.M) {
 	format := "progress" // non verbose mode
 	concurrency := 4
 
+	var specific bool
 	for _, arg := range os.Args[1:] {
 		if arg == "-test.v=true" { // go test transforms -v option - verbose mode
 			format = "pretty"
 			concurrency = 1
 			break
 		}
+		if strings.Index(arg, "-test.run") == 0 {
+			specific = true
+		}
 	}
-	status := RunWithOptions("godog", func(s *Suite) {
-		SuiteContext(s)
-	}, Options{
-		Format:      format, // pretty format for verbose mode, otherwise - progress
-		Paths:       []string{"features"},
-		Concurrency: concurrency,           // concurrency for verbose mode is 1
-		Randomize:   time.Now().UnixNano(), // randomize scenario execution order
-	})
+	var status int
+	if !specific {
+		status = RunWithOptions("godog", func(s *Suite) {
+			SuiteContext(s)
+		}, Options{
+			Format:      format, // pretty format for verbose mode, otherwise - progress
+			Paths:       []string{"features"},
+			Concurrency: concurrency,           // concurrency for verbose mode is 1
+			Randomize:   time.Now().UnixNano(), // randomize scenario execution order
+		})
+	}
 
 	if st := m.Run(); st > status {
 		status = st

--- a/suite_test.go
+++ b/suite_test.go
@@ -89,6 +89,21 @@ func SuiteContext(s *Suite) {
 	// Introduced to test formatter/cucumber.feature
 	s.Step(`^the rendered json will be as follows:$`, c.theRenderJSONWillBe)
 
+	s.Step(`^failing multistep$`, func() Steps {
+		return Steps{"passing step", "failing step"}
+	})
+
+	s.Step(`^undefined multistep$`, func() Steps {
+		return Steps{"passing step", "undefined step", "passing step"}
+	})
+
+	s.Step(`^passing multistep$`, func() Steps {
+		return Steps{"passing step", "passing step", "passing step"}
+	})
+
+	s.Step(`^failing nested multistep$`, func() Steps {
+		return Steps{"passing step", "passing multistep", "failing multistep"}
+	})
 }
 
 type firedEvent struct {


### PR DESCRIPTION
in the end should close #73 

1. [x] implement to support returning **godog.Steps** or **[]string** as multisteps on step definition func.
2. [x] add scenarios to test multistep behavior
3. [x] make some refactoring, so that **undefined** nested step, would draw correct undefined step implementation template.
4. [x] add scenarios to test undefined nested step template