### PR TITLE
Add flag to enable writing results to a file

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -55,6 +55,8 @@ func FlagSet(opt *Options) *flag.FlagSet {
 	set.BoolVar(&opt.Strict, "strict", false, "Fail suite when there are pending or undefined steps.")
 	set.BoolVar(&opt.NoColors, "no-colors", false, "Disable ansi colors.")
 	set.Var(&randomSeed{&opt.Randomize}, "random", descRandomOption)
+	set.StringVar(&opt.ResultsFile, "write", "", "Write results to a file.")
+	set.StringVar(&opt.ResultsFile, "w", "", "Write results to a file.")
 	set.Usage = usage(set, opt.Output)
 	return set
 }

--- a/options.go
+++ b/options.go
@@ -56,4 +56,7 @@ type Options struct {
 
 	// Where it should print formatter output
 	Output io.Writer
+
+	// File path to write formatter output (this will override Output)
+	ResultsFile string
 }

--- a/run.go
+++ b/run.go
@@ -143,6 +143,15 @@ func RunWithOptions(suite string, contextInitializer func(suite *Suite), opt Opt
 		return exitOptionError
 	}
 
+	if opt.ResultsFile != "" {
+		resultsOutput, err := os.Create(opt.ResultsFile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, fmt.Errorf("results file '%v': %v", opt.ResultsFile, err))
+			return exitOptionError
+		}
+		output = colors.Uncolored(resultsOutput)
+	}
+
 	r := runner{
 		fmt:           formatter(suite, output),
 		initializer:   contextInitializer,


### PR DESCRIPTION
This change adds a flag that enables writing results directly to a file, rather than needing to pipe the output.

The motivation for this is that we have a large series of tests that print debugging information to stdout, and this output gets mixed in with the result JSON, making it unparseable.

Changing the `opt.Output` property doesn't work in our case, because we use the `--output` flag to generate a binary and then run the binary in a separate environment.