### PR TITLE
Allow overriding flag defaults in BindFlags

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -52,17 +52,47 @@ func BindFlags(prefix string, set *flag.FlagSet, opt *Options) {
 	}
 	descFormatOption = strings.TrimSpace(descFormatOption)
 
-	set.StringVar(&opt.Format, prefix+"format", "pretty", descFormatOption)
-	set.StringVar(&opt.Format, prefix+"f", "pretty", descFormatOption)
-	set.StringVar(&opt.Tags, prefix+"tags", "", descTagsOption)
-	set.StringVar(&opt.Tags, prefix+"t", "", descTagsOption)
-	set.IntVar(&opt.Concurrency, prefix+"concurrency", 1, descConcurrencyOption)
-	set.IntVar(&opt.Concurrency, prefix+"c", 1, descConcurrencyOption)
-	set.BoolVar(&opt.ShowStepDefinitions, prefix+"definitions", false, "Print all available step definitions.")
-	set.BoolVar(&opt.ShowStepDefinitions, prefix+"d", false, "Print all available step definitions.")
-	set.BoolVar(&opt.StopOnFailure, prefix+"stop-on-failure", false, "Stop processing on first failed scenario.")
-	set.BoolVar(&opt.Strict, prefix+"strict", false, "Fail suite when there are pending or undefined steps.")
-	set.BoolVar(&opt.NoColors, prefix+"no-colors", false, "Disable ansi colors.")
+	// override flag defaults if any corresponding properties were supplied on the incoming `opt`
+	defFormatOption := "pretty"
+	if opt.Format != "" {
+		defFormatOption = opt.Format
+	}
+	defTagsOption := ""
+	if opt.Tags != "" {
+		defTagsOption = opt.Tags
+	}
+	defConcurrencyOption := 1
+	if opt.Concurrency != 0 {
+		defConcurrencyOption = opt.Concurrency
+	}
+	defShowStepDefinitions := false
+	if opt.ShowStepDefinitions {
+		defShowStepDefinitions = opt.ShowStepDefinitions
+	}
+	defStopOnFailure := false
+	if opt.StopOnFailure {
+		defStopOnFailure = opt.StopOnFailure
+	}
+	defStrict := false
+	if opt.Strict {
+		defStrict = opt.Strict
+	}
+	defNoColors := false
+	if opt.NoColors {
+		defNoColors = opt.NoColors
+	}
+
+	set.StringVar(&opt.Format, prefix+"format", defFormatOption, descFormatOption)
+	set.StringVar(&opt.Format, prefix+"f", defFormatOption, descFormatOption)
+	set.StringVar(&opt.Tags, prefix+"tags", defTagsOption, descTagsOption)
+	set.StringVar(&opt.Tags, prefix+"t", defTagsOption, descTagsOption)
+	set.IntVar(&opt.Concurrency, prefix+"concurrency", defConcurrencyOption, descConcurrencyOption)
+	set.IntVar(&opt.Concurrency, prefix+"c", defConcurrencyOption, descConcurrencyOption)
+	set.BoolVar(&opt.ShowStepDefinitions, prefix+"definitions", defShowStepDefinitions, "Print all available step definitions.")
+	set.BoolVar(&opt.ShowStepDefinitions, prefix+"d", defShowStepDefinitions, "Print all available step definitions.")
+	set.BoolVar(&opt.StopOnFailure, prefix+"stop-on-failure", defStopOnFailure, "Stop processing on first failed scenario.")
+	set.BoolVar(&opt.Strict, prefix+"strict", defStrict, "Fail suite when there are pending or undefined steps.")
+	set.BoolVar(&opt.NoColors, prefix+"no-colors", defNoColors, "Disable ansi colors.")
 	set.Var(&randomSeed{&opt.Randomize}, prefix+"random", descRandomOption)
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -2,6 +2,7 @@ package godog
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -73,5 +74,128 @@ func TestFlagsUsageShouldIncludeFormatDescriptons(t *testing.T) {
 		if idx := strings.Index(out, match); idx == -1 {
 			t.Fatalf("could not locate format: %s description in flag usage", name)
 		}
+	}
+}
+
+func TestBindFlagsShouldRespectFlagDefaults(t *testing.T) {
+	opts := Options{}
+
+	BindFlags("flagDefaults.", flag.CommandLine, &opts)
+
+	if opts.Format != "pretty" {
+		t.Fatalf("expected Format: pretty, but it was: %s", opts.Format)
+	}
+	if opts.Tags != "" {
+		t.Fatalf("expected Tags: '', but it was: %s", opts.Tags)
+	}
+	if opts.Concurrency != 1 {
+		t.Fatalf("expected Concurrency: 1, but it was: %d", opts.Concurrency)
+	}
+	if opts.ShowStepDefinitions {
+		t.Fatalf("expected ShowStepDefinitions: false, but it was: %t", opts.ShowStepDefinitions)
+	}
+	if opts.StopOnFailure {
+		t.Fatalf("expected StopOnFailure: false, but it was: %t", opts.StopOnFailure)
+	}
+	if opts.Strict {
+		t.Fatalf("expected Strict: false, but it was: %t", opts.Strict)
+	}
+	if opts.NoColors {
+		t.Fatalf("expected NoColors: false, but it was: %t", opts.NoColors)
+	}
+	if opts.Randomize != 0 {
+		t.Fatalf("expected Randomize: 0, but it was: %d", opts.Randomize)
+	}
+}
+
+func TestBindFlagsShouldRespectOptDefaults(t *testing.T) {
+	opts := Options{
+		Format:              "progress",
+		Tags:                "test",
+		Concurrency:         2,
+		ShowStepDefinitions: true,
+		StopOnFailure:       true,
+		Strict:              true,
+		NoColors:            true,
+		Randomize:           int64(7),
+	}
+
+	BindFlags("optDefaults.", flag.CommandLine, &opts)
+
+	if opts.Format != "progress" {
+		t.Fatalf("expected Format: progress, but it was: %s", opts.Format)
+	}
+	if opts.Tags != "test" {
+		t.Fatalf("expected Tags: 'test', but it was: %s", opts.Tags)
+	}
+	if opts.Concurrency != 2 {
+		t.Fatalf("expected Concurrency: 2, but it was: %d", opts.Concurrency)
+	}
+	if !opts.ShowStepDefinitions {
+		t.Fatalf("expected ShowStepDefinitions: true, but it was: %t", opts.ShowStepDefinitions)
+	}
+	if !opts.StopOnFailure {
+		t.Fatalf("expected StopOnFailure: true, but it was: %t", opts.StopOnFailure)
+	}
+	if !opts.Strict {
+		t.Fatalf("expected Strict: true, but it was: %t", opts.Strict)
+	}
+	if !opts.NoColors {
+		t.Fatalf("expected NoColors: true, but it was: %t", opts.NoColors)
+	}
+	if opts.Randomize != 7 {
+		t.Fatalf("expected Randomize: 7, but it was: %d", opts.Randomize)
+	}
+}
+
+func TestBindFlagsShouldRespectFlagOverrides(t *testing.T) {
+	opts := Options{
+		Format:              "progress",
+		Tags:                "test",
+		Concurrency:         2,
+		ShowStepDefinitions: true,
+		StopOnFailure:       true,
+		Strict:              true,
+		NoColors:            true,
+		Randomize:           11,
+	}
+	flagSet := flag.FlagSet{}
+
+	BindFlags("optOverrides.", &flagSet, &opts)
+
+	flagSet.Parse([]string{
+		"--optOverrides.format=junit",
+		"--optOverrides.tags=test2",
+		"--optOverrides.concurrency=3",
+		"--optOverrides.definitions=false",
+		"--optOverrides.stop-on-failure=false",
+		"--optOverrides.strict=false",
+		"--optOverrides.no-colors=false",
+		"--optOverrides.random=2",
+	})
+
+	if opts.Format != "junit" {
+		t.Fatalf("expected Format: junit, but it was: %s", opts.Format)
+	}
+	if opts.Tags != "test2" {
+		t.Fatalf("expected Tags: 'test2', but it was: %s", opts.Tags)
+	}
+	if opts.Concurrency != 3 {
+		t.Fatalf("expected Concurrency: 3, but it was: %d", opts.Concurrency)
+	}
+	if opts.ShowStepDefinitions {
+		t.Fatalf("expected ShowStepDefinitions: true, but it was: %t", opts.ShowStepDefinitions)
+	}
+	if opts.StopOnFailure {
+		t.Fatalf("expected StopOnFailure: true, but it was: %t", opts.StopOnFailure)
+	}
+	if opts.Strict {
+		t.Fatalf("expected Strict: true, but it was: %t", opts.Strict)
+	}
+	if opts.NoColors {
+		t.Fatalf("expected NoColors: true, but it was: %t", opts.NoColors)
+	}
+	if opts.Randomize != 2 {
+		t.Fatalf("expected Randomize: 2, but it was: %d", opts.Randomize)
 	}
 }


### PR DESCRIPTION
This is an implementation of the feature request @ https://github.com/DATA-DOG/godog/issues/143. `BindFlags` has been updated to use any non-empty `opt` properties as default overrides. For any empty `opt` properties, the default... defaults are used.

closes #143 